### PR TITLE
added missing dependency (pytz) to install_requires

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -30,5 +30,6 @@ setup(
     install_requires=[
 		'Django==1.5.4',
 		'feedparser==5.1.3',
+		'pytz==2013.7'
     ],
 )


### PR DESCRIPTION
Discovered after a clean setup on windows

Theoretically, the feedparser dependency could/should install it, but that doesn't happen for whatever reason.  Also, since the [feedreader code uses it directly](https://github.com/ahernp/django-feedreader/blob/master/feedreader/utils.py#L2),  probably it should be included in this [setup file](https://github.com/ahernp/django-feedreader/blob/master/setup.py#L30) too

Platform info to reproduce:

`$ win_info
OS Name:                   Microsoft Windows 7 Professional
OS Manufacturer:           Microsoft Corporation
System Type:               x64-based PC
System Locale:             en-us;English (United States)
Input Locale:              en-us;English (United States)
$ python --version
Python 2.7.4
$ virtualenv repro --no-site-packages
$ source repro/Scripts/activate
$ pip install django-feedreader
$ pip freeze
Django==1.5.4
django-feedreader==0.7.6
feedparser==5.1.3
$ git --version
git version 1.8.1.msysgit.1`
