### PR TITLE
Fix offset-naive and offset-aware datetimes TypeError

### DIFF
--- a/feedreader/utils.py
+++ b/feedreader/utils.py
@@ -180,12 +180,14 @@ def poll_feed(db_feed, verbose=False):
                     published_time = timezone.now()
                 else:
                     published_time = datetime.fromtimestamp(mktime(entry.published_parsed))
-                    try:
-                        published_time = pytz.timezone(settings.TIME_ZONE).localize(published_time, is_dst=None)
-                    except pytz.exceptions.AmbiguousTimeError:
-                        pytz_timezone = pytz.timezone(settings.TIME_ZONE)
-                        published_time = pytz_timezone.localize(published_time, is_dst=False)
                     now = timezone.now()
+                    pytz_timezone = pytz.timezone(settings.TIME_ZONE)
+                    try:
+                        published_time = pytz_timezone.localize(published_time, is_dst=None)
+                        now = pytz_timezone.localize(now, is_dst=None)
+                    except pytz.exceptions.AmbiguousTimeError:
+                        published_time = pytz_timezone.localize(published_time, is_dst=False)
+                        now = pytz_timezone.localize(now, is_dst=False)
                     if published_time > now:
                         published_time = now
                 db_entry.published_time = published_time


### PR DESCRIPTION
I had an issue while trying your library with python==3.6.5 and django==2.2.6.
I added some feeds such as:
https://feeds.finance.yahoo.com/rss/2.0/headline?s=yhoo&region=US&lang=en-US
http://feeds.reuters.com/Reuters/domesticNews

And when calling `python manage.py poll_feeds`, this is what I got:

```
Traceback (most recent call last):
  File "manage.py", line 16, in <module>
    execute_from_command_line(sys.argv)
  File "/home/user/.virtualenvs/myenv/local/lib/python3.6/site-packages/django/core/management/__init__.py", line 381, in execute_from_command_line
    utility.execute()
  File "/home/user/.virtualenvs/myenv/local/lib/python3.6/site-packages/django/core/management/__init__.py", line 375, in execute
    self.fetch_command(subcommand).run_from_argv(self.argv)
  File "/home/user/.virtualenvs/myenv/local/lib/python3.6/site-packages/django/core/management/base.py", line 323, in run_from_argv
    self.execute(*args, **cmd_options)
  File "/home/user/.virtualenvs/myenv/local/lib/python3.6/site-packages/django/core/management/base.py", line 364, in execute
    output = self.handle(*args, **options)
  File "/home/user/.virtualenvs/myenv/src/feedreader/feedreader/management/commands/poll_feeds.py", line 43, in handle
    poll_feed(feed, verbose)
  File "/home/user/.virtualenvs/myenv/src/feedreader/feedreader/utils.py", line 191, in poll_feed
    if published_time > now:
TypeError: can't compare offset-naive and offset-aware datetimes
```

So I have updated the poll_feed function in `feedreader/utils.py` in order to compare datetimes with the same timezone. The tests inside `test_utils.py` are ok !